### PR TITLE
String Escape and Double Key Bug Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.3.1] - 2022-05-03
+
+### Changed
+
+- Fixed an issue where quotes in string values would not be escaped. #11
+- Fixed an issue where int64 and byte values would get a double key. #12, #13
+
 ## [0.3.0] - 2022-04-19
 
 ### Changed

--- a/json_serialization_writer.go
+++ b/json_serialization_writer.go
@@ -26,6 +26,7 @@ func (w *JsonSerializationWriter) writeRawValue(value string) {
 	w.writer = append(w.writer, value)
 }
 func (w *JsonSerializationWriter) writeStringValue(value string) {
+        value = strings.ReplaceAll(value, "\"", "\\\"")
 	w.writeRawValue("\"" + value + "\"")
 }
 func (w *JsonSerializationWriter) writePropertyName(key string) {
@@ -83,30 +84,18 @@ func (w *JsonSerializationWriter) WriteBoolValue(key string, value *bool) error 
 
 // WriteByteValue writes a Byte value to underlying the byte array.
 func (w *JsonSerializationWriter) WriteByteValue(key string, value *byte) error {
-	if key != "" && value != nil {
-		w.writePropertyName(key)
-	}
 	if value != nil {
 		cast := int64(*value)
 		return w.WriteInt64Value(key, &cast)
-	}
-	if key != "" && value != nil {
-		w.writePropertySeparator()
 	}
 	return nil
 }
 
 // WriteInt8Value writes a int8 value to underlying the byte array.
 func (w *JsonSerializationWriter) WriteInt8Value(key string, value *int8) error {
-	if key != "" && value != nil {
-		w.writePropertyName(key)
-	}
 	if value != nil {
 		cast := int64(*value)
 		return w.WriteInt64Value(key, &cast)
-	}
-	if key != "" && value != nil {
-		w.writePropertySeparator()
 	}
 	return nil
 }

--- a/json_serialization_writer_test.go
+++ b/json_serialization_writer_test.go
@@ -77,3 +77,50 @@ func TestWriteDateOnlyValue(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, fmt.Sprintf("\"key\":%q,", value), string(result[:]))
 }
+
+
+func TestWriteBoolValue(t *testing.T) {
+	serializer := NewJsonSerializationWriter()
+	value := true
+	serializer.WriteBoolValue("key", &value)
+	result, err := serializer.GetSerializedContent()
+	assert.Nil(t, err)
+	assert.Equal(t, fmt.Sprintf("\"key\":%t,", value), string(result[:]))
+}
+
+func TestWriteInt8Value(t *testing.T) {
+	serializer := NewJsonSerializationWriter()
+	value := int8(125)
+	serializer.WriteInt8Value("key", &value)
+	result, err := serializer.GetSerializedContent()
+	assert.Nil(t, err)
+	assert.Equal(t, fmt.Sprintf("\"key\":%d,", value), string(result[:]))
+}
+
+func TestWriteByteValue(t *testing.T) {
+	serializer := NewJsonSerializationWriter()
+	var value byte = 97
+	serializer.WriteByteValue("key", &value)
+	result, err := serializer.GetSerializedContent()
+	assert.Nil(t, err)
+	assert.Equal(t, fmt.Sprintf("\"key\":%d,", value), string(result[:]))
+}
+//  ByteArray values are encoded to Base64 when stored
+func TestWriteByteArrayValue(t *testing.T) {
+	serializer := NewJsonSerializationWriter()
+	value := []byte("SerialWriter")
+	serializer.WriteByteArrayValue("key", value)
+	expected := "U2VyaWFsV3JpdGVy"
+	result, err := serializer.GetSerializedContent()
+	assert.Nil(t, err)
+	assert.Equal(t, fmt.Sprintf("\"key\":\"%s\",", expected), string(result[:]))
+}
+
+func TestDoubleEscapeFailure( t *testing.T) {
+	serializer := NewJsonSerializationWriter()
+	value := "W/\"CQAAABYAAAAs+XSiyjZdS4Rhtwk0v1pGAAC5bsJ2\""
+	serializer.WriteStringValue("key", &value)
+	result, err := serializer.GetSerializedContent()
+	assert.Nil(t, err)
+	assert.Equal(t, fmt.Sprintf("\"key\":%q,", value), string(result[:]))
+}


### PR DESCRIPTION
Fix for Issue #11. `TestDoubleEscapeFailure` corresponds to the fix. 
Issue #12: Duplicate key fix. Format changed to match `WriteInt32Value()`. 
Issue #13: Key duplication removed. See comments within issue to verify the desired operation.