### PR TITLE
- fixed a bug where a backslash in a string would result in an invalid payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.5.4] - 2022-06-30
+
+### Changed
+
+- Fixed a bug where a backslash in a string would result in an invalid payload.
+
 ## [0.5.3] - 2022-06-09
 
 ### Changed

--- a/json_serialization_writer.go
+++ b/json_serialization_writer.go
@@ -27,7 +27,15 @@ func (w *JsonSerializationWriter) writeRawValue(value string) {
 	w.writer = append(w.writer, value)
 }
 func (w *JsonSerializationWriter) writeStringValue(value string) {
-	value = strings.ReplaceAll(strings.ReplaceAll(value, "\"", "\\\""), "\n", "\\n")
+	value = strings.ReplaceAll(
+		strings.ReplaceAll(
+			strings.ReplaceAll(value,
+				"\\", "\\\\",
+			),
+			"\"",
+			"\\\""),
+		"\n",
+		"\\n")
 	w.writeRawValue("\"" + value + "\"")
 }
 func (w *JsonSerializationWriter) writePropertyName(key string) {

--- a/json_serialization_writer_test.go
+++ b/json_serialization_writer_test.go
@@ -1,6 +1,7 @@
 package jsonserialization
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -192,4 +193,29 @@ func TestEscapesNewLinesInStrings(t *testing.T) {
 	result, err := serializer.GetSerializedContent()
 	assert.Nil(t, err)
 	assert.Equal(t, "\"key\":\"value\\nwith\\nnew\\nlines\"", string(result[:]))
+
+	fullPayload := "{" + string(result[:]) + "}"
+	var parsedResult TestStruct
+	parseErr := json.Unmarshal([]byte(fullPayload), &parsedResult)
+	assert.Nil(t, parseErr)
+	assert.Equal(t, value, parsedResult.Key)
+}
+
+func TestEscapesBackslashesInStrings(t *testing.T) {
+	serializer := NewJsonSerializationWriter()
+	value := "value\\with\\backslashes"
+	serializer.WriteStringValue("key", &value)
+	result, err := serializer.GetSerializedContent()
+	assert.Nil(t, err)
+	assert.Equal(t, "\"key\":\"value\\\\with\\\\backslashes\"", string(result[:]))
+
+	fullPayload := "{" + string(result[:]) + "}"
+	var parsedResult TestStruct
+	parseErr := json.Unmarshal([]byte(fullPayload), &parsedResult)
+	assert.Nil(t, parseErr)
+	assert.Equal(t, value, parsedResult.Key)
+}
+
+type TestStruct struct {
+	Key string `json:"key"`
 }


### PR DESCRIPTION
fixes https://github.com/microsoftgraph/msgraph-sdk-go/issues/203