### PR TITLE
Fixes escape of \t and \r

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [0.5.4] - 2022-07-11
+
+- Fixed bug where string literals of `\t` and `\r` would result in generating an invalid JSON. 
+
 ### Changed
 
 ## [0.5.4] - 2022-06-30

--- a/json_serialization_writer.go
+++ b/json_serialization_writer.go
@@ -27,6 +27,8 @@ func (w *JsonSerializationWriter) writeRawValue(value string) {
 	w.writer = append(w.writer, value)
 }
 func (w *JsonSerializationWriter) writeStringValue(value string) {
+	value = strings.ReplaceAll(strings.ReplaceAll(value, "\t", ""), "\r", "")
+
 	value = strings.ReplaceAll(
 		strings.ReplaceAll(
 			strings.ReplaceAll(value,

--- a/json_serialization_writer.go
+++ b/json_serialization_writer.go
@@ -27,7 +27,6 @@ func (w *JsonSerializationWriter) writeRawValue(value string) {
 	w.writer = append(w.writer, value)
 }
 func (w *JsonSerializationWriter) writeStringValue(value string) {
-	value = strings.ReplaceAll(strings.ReplaceAll(value, "\t", ""), "\r", "")
 
 	value = strings.ReplaceAll(
 		strings.ReplaceAll(
@@ -38,6 +37,7 @@ func (w *JsonSerializationWriter) writeStringValue(value string) {
 			"\\\""),
 		"\n",
 		"\\n")
+	value = strings.ReplaceAll(strings.ReplaceAll(value, "\t", "\\t"), "\r", "\\r")
 	w.writeRawValue("\"" + value + "\"")
 }
 func (w *JsonSerializationWriter) writePropertyName(key string) {

--- a/json_serialization_writer_test.go
+++ b/json_serialization_writer_test.go
@@ -216,6 +216,18 @@ func TestEscapesBackslashesInStrings(t *testing.T) {
 	assert.Equal(t, value, parsedResult.Key)
 }
 
+func TestEscapeTabAndCarriageReturnInStrings(t *testing.T) {
+	doubleB := "<html lang=\"en\" style=\"min-height:100%;\t background:#ffffff\"><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"><meta name=\"viewport\" content=\"width=device-width\"><meta name=\"eventId\" ^Mcontent=\"aad-identity-protection-weekly-digest-report-v2\"><meta name=\"messageId\" content=\"d4db577e-fe10-4bea-8e6d-164bb1ebb039\">"
+	expected := "\"<html lang=\\\"en\\\" style=\\\"min-height:100%;\\t background:#ffffff\\\"><head><meta http-equiv=\\\"Content-Type\\\" content=\\\"text/html; charset=utf-8\\\"><meta name=\\\"viewport\\\" content=\\\"width=device-width\\\"><meta name=\\\"eventId\\\" ^Mcontent=\\\"aad-identity-protection-weekly-digest-report-v2\\\"><meta name=\\\"messageId\\\" content=\\\"d4db577e-fe10-4bea-8e6d-164bb1ebb039\\\">\""
+	serializer := NewJsonSerializationWriter()
+	err := serializer.WriteStringValue("", &doubleB)
+	assert.NoError(t, err)
+	result, err := serializer.GetSerializedContent()
+	assert.NoError(t, err)
+	converted := string(result)
+	assert.Equal(t, expected, converted)
+}
+
 type TestStruct struct {
 	Key string `json:"key"`
 }


### PR DESCRIPTION
Fixes #30 
- Did not add any tests. Passes all current tests. I used a file to upload a full file with \r and \t to ensure that a valid json was output. 