### PR TITLE
Adds new implementation methods in kiota abstractions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.7.0] - 2022-09-22
+
+### Added
+
+- Implement additional serialization method `WriteAnyValues` and parse method `GetRawValue`.
+
 ## [0.6.0] - 2022-09-02
 
 ### Added

--- a/json_parse_node.go
+++ b/json_parse_node.go
@@ -185,7 +185,11 @@ func (n *JsonParseNode) GetObjectValue(ctor absser.ParsableFactory) (absser.Pars
 			field := fields[key]
 			if field == nil {
 				if value != nil && isHolder {
-					itemAdditionalData[key] = value.value
+					rawValue, err := value.GetRawValue()
+					if err != nil {
+						return nil, err
+					}
+					itemAdditionalData[key] = rawValue
 				}
 			} else {
 				err := field(value)
@@ -473,4 +477,9 @@ func (n *JsonParseNode) GetByteArrayValue() ([]byte, error) {
 		return nil, nil
 	}
 	return base64.StdEncoding.DecodeString(*s)
+}
+
+// GetRawValue returns a ByteArray value from the nodes.
+func (n *JsonParseNode) GetRawValue() (interface{}, error) {
+	return n.value, nil
 }

--- a/json_serialization_writer.go
+++ b/json_serialization_writer.go
@@ -2,7 +2,7 @@ package jsonserialization
 
 import (
 	"encoding/base64"
-	"fmt"
+	"encoding/json"
 	"strconv"
 	"strings"
 	"time"
@@ -609,6 +609,27 @@ func (w *JsonSerializationWriter) GetSerializedContent() ([]byte, error) {
 	return []byte(resultStr), nil
 }
 
+// WriteAnyValues an unknown value as a parameter.
+func (w *JsonSerializationWriter) WriteAnyValues(key string, value interface{}) error {
+
+	if value != nil {
+		body, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		if key != "" {
+			w.writePropertyName(key)
+		}
+
+		w.writeRawValue(string(body))
+
+		if key != "" {
+			w.writePropertySeparator()
+		}
+	}
+	return nil
+}
+
 // WriteAdditionalData writes additional data to underlying the byte array.
 func (w *JsonSerializationWriter) WriteAdditionalData(value map[string]interface{}) error {
 	var err error
@@ -698,7 +719,7 @@ func (w *JsonSerializationWriter) WriteAdditionalData(value map[string]interface
 			case absser.DateOnly:
 				err = w.WriteDateOnlyValue(key, &value)
 			default:
-				return fmt.Errorf("unsupported AdditionalData type: %T", value)
+				err = w.WriteAnyValues(key, &value)
 			}
 		}
 	}


### PR DESCRIPTION
Resolves https://github.com/microsoftgraph/msgraph-sdk-go/issues/258
Blocked by https://github.com/microsoft/kiota-abstractions-go/pull/35

Allows attempting to serialize properties with undefined serializers before throwing an error