### PR TITLE
Fix/GetRawValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.7.2] - 2022-09-29
+
+### Changed
+
+- Fix: Bug on GetRawValue results to invalid memory address when server responds with a `null` on the request body field.
+
 ## [0.7.1] - 2022-09-26
 
 ### Changed

--- a/json_parse_node.go
+++ b/json_parse_node.go
@@ -481,5 +481,8 @@ func (n *JsonParseNode) GetByteArrayValue() ([]byte, error) {
 
 // GetRawValue returns a ByteArray value from the nodes.
 func (n *JsonParseNode) GetRawValue() (interface{}, error) {
+	if n == nil || n.value == nil {
+		return nil, nil
+	}
 	return n.value, nil
 }

--- a/json_parse_node_test.go
+++ b/json_parse_node_test.go
@@ -1,6 +1,7 @@
 package jsonserialization
 
 import (
+	"github.com/stretchr/testify/require"
 	testing "testing"
 
 	absser "github.com/microsoft/kiota-abstractions-go/serialization"
@@ -56,6 +57,26 @@ func TestTree(t *testing.T) {
 	}
 }
 
+func TestGetRawValue(t *testing.T) {
+	source := `{
+				"id": "2",
+				"status": 200,
+				"item": null
+		  }`
+	sourceArray := []byte(source)
+	parseNode, err := NewJsonParseNode(sourceArray)
+	if err != nil {
+		t.Errorf("Error creating parse node: %s", err.Error())
+	}
+	someProp, err := parseNode.GetChildNode("item")
+	value, err := someProp.GetRawValue()
+	require.NoError(t, err)
+	assert.Nil(t, value)
+
+	someProp, err = parseNode.GetChildNode("status")
+	value, err = someProp.GetRawValue()
+	assert.Equal(t, float64(200), *value.(*float64))
+}
 func TestJsonParseNodeHonoursInterface(t *testing.T) {
 	instance := &JsonParseNode{}
 	assert.Implements(t, (*absser.ParseNode)(nil), instance)


### PR DESCRIPTION
Desciption
`GetRawValue` fails when the response returned is `null` on the accessed field.

Testing:
Added unit tests