### PR TITLE
Fix get raw value response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.8.1] - 2023-02-20
+
+### Added
+
+- Fixes bug that returned `JsonParseNode` as value for collections when `GetRawValue` is called.
+
 ## [0.8.0] - 2023-01-23
 
 ### Added

--- a/json_parse_node.go
+++ b/json_parse_node.go
@@ -510,7 +510,22 @@ func (n *JsonParseNode) GetRawValue() (interface{}, error) {
 	if n == nil || n.value == nil {
 		return nil, nil
 	}
-	return n.value, nil
+	switch v := n.value.(type) {
+	case *JsonParseNode:
+		return v.GetRawValue()
+	case []*JsonParseNode:
+		result := make([]interface{}, len(v))
+		for i, x := range v {
+			val, err := x.GetRawValue()
+			if err != nil {
+				return nil, err
+			}
+			result[i] = val
+		}
+		return result, nil
+	default:
+		return n.value, nil
+	}
 }
 
 func (n *JsonParseNode) GetOnBeforeAssignFieldValues() absser.ParsableAction {

--- a/json_parse_node_test.go
+++ b/json_parse_node_test.go
@@ -61,7 +61,8 @@ func TestGetRawValue(t *testing.T) {
 	source := `{
 				"id": "2",
 				"status": 200,
-				"item": null
+				"item": null,
+				"phones": [1,2,3]
 		  }`
 	sourceArray := []byte(source)
 	parseNode, err := NewJsonParseNode(sourceArray)
@@ -76,7 +77,22 @@ func TestGetRawValue(t *testing.T) {
 	someProp, err = parseNode.GetChildNode("status")
 	value, err = someProp.GetRawValue()
 	assert.Equal(t, float64(200), *value.(*float64))
+
+	someProp, err = parseNode.GetChildNode("phones")
+	value, err = someProp.GetRawValue()
+
+	var expected []interface{}
+	expected = append(expected, ref(float64(1)))
+	expected = append(expected, ref(float64(2)))
+	expected = append(expected, ref(float64(3)))
+
+	assert.Equal(t, expected, value)
 }
+
+func ref[T interface{}](t T) *T {
+	return &t
+}
+
 func TestJsonParseNodeHonoursInterface(t *testing.T) {
 	instance := &JsonParseNode{}
 	assert.Implements(t, (*absser.ParseNode)(nil), instance)


### PR DESCRIPTION
Unwraps slice values when `GetRawValue` is returned. This bug causes issues in serialization of additional data where no types information has been provided

Resolves https://github.com/microsoftgraph/msgraph-sdk-go/issues/396