### PR TITLE
Fixes get raw value for maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.8.2] - 2023-03-01
+
+### Added
+
+- Fixes bug that returned `JsonParseNode` as value for nested maps when `GetRawValue` is called.
+
 ## [0.8.1] - 2023-02-20
 
 ### Added

--- a/json_parse_node.go
+++ b/json_parse_node.go
@@ -523,6 +523,16 @@ func (n *JsonParseNode) GetRawValue() (interface{}, error) {
 			result[i] = val
 		}
 		return result, nil
+	case map[string]*JsonParseNode:
+		m := make(map[string]interface{})
+		for key, element := range v {
+			elementVal, err := element.GetRawValue()
+			if err != nil {
+				return nil, err
+			}
+			m[key] = elementVal
+		}
+		return m, nil
 	default:
 		return n.value, nil
 	}

--- a/json_parse_node_test.go
+++ b/json_parse_node_test.go
@@ -89,6 +89,37 @@ func TestGetRawValue(t *testing.T) {
 	assert.Equal(t, expected, value)
 }
 
+func TestNestedGetRawValue(t *testing.T) {
+	source := `{
+				"id": "2",
+				"status": 200,
+				"item": null,
+				"phones": [1,2,3],
+				"passwordCredentials": [
+					{
+						"endDateTime": "2023-07-11T14:18:14.946Z",
+						"keyId": "f92ec133-34aa-49e9-b078-9f0b247d8059"
+					}
+				]
+		  }`
+	sourceArray := []byte(source)
+	parseNode, err := NewJsonParseNode(sourceArray)
+	if err != nil {
+		t.Errorf("Error creating parse node: %s", err.Error())
+	}
+	someProp, err := parseNode.GetChildNode("passwordCredentials")
+	value, err := someProp.GetRawValue()
+	require.NoError(t, err)
+
+	var expected []interface{}
+	e := make(map[string]interface{})
+	e["endDateTime"] = ref("2023-07-11T14:18:14.946Z")
+	e["keyId"] = ref("f92ec133-34aa-49e9-b078-9f0b247d8059")
+	expected = append(expected, e)
+
+	assert.Equal(t, expected, value)
+}
+
 func ref[T interface{}](t T) *T {
 	return &t
 }


### PR DESCRIPTION
Fixes parsing raw values of unmapped additionalData, this should fix serialization bug mentioned [here ](https://github.com/microsoftgraph/msgraph-sdk-go/issues/396)