### PR TITLE
Validate json content before parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
 ### Changed
+
+### Added
+
+## [0.8.3] - 2023-03-20
+
+### Added
+
+- Validates json content before parsing.
 
 ## [0.8.2] - 2023-03-01
 

--- a/json_parse_node.go
+++ b/json_parse_node.go
@@ -27,6 +27,9 @@ func NewJsonParseNode(content []byte) (*JsonParseNode, error) {
 	if len(content) == 0 {
 		return nil, errors.New("content is empty")
 	}
+	if !json.Valid(content) {
+		return nil, errors.New("invalid json type")
+	}
 	decoder := json.NewDecoder(bytes.NewReader(content))
 	value, err := loadJsonTree(decoder)
 	return value, err

--- a/json_parse_node_factory_test.go
+++ b/json_parse_node_factory_test.go
@@ -12,3 +12,12 @@ func TestJsonParseNodeFactoryHonoursInterface(t *testing.T) {
 	instance := NewJsonParseNodeFactory()
 	assert.Implements(t, (*absser.ParseNodeFactory)(nil), instance)
 }
+
+func TestInvalidContentShouldFail(t *testing.T) {
+	source := "3 [ }"
+	sourceArray := []byte(source)
+
+	parseNode, err := NewJsonParseNode(sourceArray)
+	assert.Error(t, err)
+	assert.Nil(t, parseNode)
+}


### PR DESCRIPTION
Validates json content before attempting to serialize. 
Currently when an invalid json string is passed to the factory, the string will be be parsed, but the result will be a `nil` value. 
The current PR ensures that an error is thrown when source string is not a valid json 

Fixes https://github.com/microsoft/kiota-serialization-json-go/issues/69