### PR TITLE
Print unknown type error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [0.9.1] - 2023-04-05
+
+### Added
+
+- Improve error messaging for serialization error.
+
 ## [0.9.0] - 2023-03-30
 
 ### Added

--- a/json_parse_node.go
+++ b/json_parse_node.go
@@ -7,10 +7,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"github.com/google/uuid"
 	"io"
 	"time"
 
-	"github.com/google/uuid"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 	absser "github.com/microsoft/kiota-abstractions-go/serialization"
 )
@@ -308,7 +309,7 @@ func (n *JsonParseNode) getPrimitiveValue(targetType string) (interface{}, error
 	case "base64":
 		return n.GetByteArrayValue()
 	default:
-		return nil, errors.New("targetType is not supported")
+		return nil, fmt.Errorf("targetType %s is not supported", targetType)
 	}
 }
 

--- a/json_parse_node_test.go
+++ b/json_parse_node_test.go
@@ -140,6 +140,24 @@ func TestFunctional(t *testing.T) {
 	}
 }
 
+func TestThrowErrorOfPrimitiveType(t *testing.T) {
+	source := `{
+				"id": "2",
+				"status": 200,
+				"item": null,
+				"phones": [1,2,3]
+		  }`
+	sourceArray := []byte(source)
+	parseNode, err := NewJsonParseNode(sourceArray)
+	if err != nil {
+		t.Errorf("Error creating parse node: %s", err.Error())
+	}
+
+	someProp, err := parseNode.GetChildNode("phones")
+	_, err = someProp.GetCollectionOfPrimitiveValues("wrong.UUID")
+	assert.Equal(t, "targetType wrong.UUID is not supported", err.Error())
+}
+
 const FunctionalTestSource = "{" +
 	"\"@odata.context\": \"https://graph.microsoft.com/v1.0/$metadata#users('vincent%40biret365.onmicrosoft.com')/messages\"," +
 	"\"@odata.nextLink\": \"https://graph.microsoft.com/v1.0/users/vincent@biret365.onmicrosoft.com/messages?$skip=10\"," +


### PR DESCRIPTION
Partialy address https://github.com/microsoftgraph/msgraph-beta-sdk-go/issues/259

When a serialization error occurs it's fairly difficult to track down the primitive type that is causing the error. This pr improves the serialization error message by including the Uknown target type therefore improving the error message.