### PR TITLE
use buffer to improve JsonSerializationWriter performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Improve `JsonSerializationWriter` serialization performance.
+
+## [0.9.2] - 2023-04-17
+
+### Added
+
 ## [0.9.1] - 2023-04-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Improve `JsonSerializationWriter` serialization performance.
 
 ## [0.9.2] - 2023-04-17
 
-### Added
+### Changed
+
+- Improve `JsonSerializationWriter` serialization performance.
 
 ## [0.9.1] - 2023-04-05
 

--- a/json_serialization_writer.go
+++ b/json_serialization_writer.go
@@ -1,6 +1,7 @@
 package jsonserialization
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"strconv"
@@ -15,7 +16,8 @@ import (
 
 // JsonSerializationWriter implements SerializationWriter for JSON.
 type JsonSerializationWriter struct {
-	writer                     []string
+	writer                     *bytes.Buffer
+	separatorIndices           []int
 	onBeforeAssignFieldValues  absser.ParsableAction
 	onAfterAssignFieldValues   absser.ParsableAction
 	onStartObjectSerialization absser.ParsableWriter
@@ -24,39 +26,30 @@ type JsonSerializationWriter struct {
 // NewJsonSerializationWriter creates a new instance of the JsonSerializationWriter.
 func NewJsonSerializationWriter() *JsonSerializationWriter {
 	return &JsonSerializationWriter{
-		writer: make([]string, 0),
+		writer:           new(bytes.Buffer),
+		separatorIndices: make([]int, 0),
 	}
 }
-func (w *JsonSerializationWriter) writeRawValue(value string) {
-	w.writer = append(w.writer, value)
+func (w *JsonSerializationWriter) writeRawValue(value ...string) {
+	for _, v := range value {
+		w.writer.WriteString(v)
+	}
 }
 func (w *JsonSerializationWriter) writeStringValue(value string) {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `"`, `\"`)
+	value = strings.ReplaceAll(value, "\n", `\n`)
+	value = strings.ReplaceAll(value, "\r", `\r`)
+	value = strings.ReplaceAll(value, "\t", `\t`)
 
-	value = strings.ReplaceAll(
-		strings.ReplaceAll(
-			strings.ReplaceAll(value,
-				"\\", "\\\\",
-			),
-			"\"",
-			"\\\""),
-		"\n",
-		"\\n")
-	value = strings.ReplaceAll(strings.ReplaceAll(value, "\t", "\\t"), "\r", "\\r")
-	w.writeRawValue("\"" + value + "\"")
+	w.writeRawValue("\"", value, "\"")
 }
 func (w *JsonSerializationWriter) writePropertyName(key string) {
-	w.writeRawValue("\"" + key + "\":")
+	w.writeRawValue("\"", key, "\":")
 }
 func (w *JsonSerializationWriter) writePropertySeparator() {
+	w.separatorIndices = append(w.separatorIndices, w.writer.Len())
 	w.writeRawValue(",")
-}
-func (w *JsonSerializationWriter) trimLastPropertySeparator() {
-	for idx, s := range w.writer {
-		writerLen := len(w.writer)
-		if s == "," && (idx == writerLen-1 || (idx < writerLen-1 && (w.writer[idx+1] == "]" || w.writer[idx+1] == "}" || w.writer[idx+1] == ","))) {
-			w.writer[idx] = ""
-		}
-	}
 }
 func (w *JsonSerializationWriter) writeArrayStart() {
 	w.writeRawValue("[")
@@ -614,14 +607,29 @@ func (w *JsonSerializationWriter) WriteCollectionOfInt8Values(key string, collec
 
 // GetSerializedContent returns the resulting byte array from the serialization writer.
 func (w *JsonSerializationWriter) GetSerializedContent() ([]byte, error) {
-	w.trimLastPropertySeparator()
-	resultStr := strings.Join(w.writer, "")
-	return []byte(resultStr), nil
+	written := w.writer.Bytes()
+	writtenLen := len(written)
+	trimmed := make([]byte, 0, writtenLen)
+
+	sliceStart := 0
+	for _, idx := range w.separatorIndices {
+		trimmed = append(trimmed, written[sliceStart:idx]...)
+		sliceStart = idx
+
+		if idx == writtenLen-1 || idx < writtenLen-1 && (written[idx+1] == byte(']') || written[idx+1] == byte('}') || written[idx+1] == byte(',')) {
+			sliceStart++
+		}
+	}
+
+	if sliceStart <= writtenLen-1 {
+		trimmed = append(trimmed, written[sliceStart:]...)
+	}
+
+	return trimmed, nil
 }
 
 // WriteAnyValue an unknown value as a parameter.
 func (w *JsonSerializationWriter) WriteAnyValue(key string, value interface{}) error {
-
 	if value != nil {
 		body, err := json.Marshal(value)
 		if err != nil {
@@ -779,6 +787,7 @@ func (w *JsonSerializationWriter) WriteAdditionalData(value map[string]interface
 
 // Close clears the internal buffer.
 func (w *JsonSerializationWriter) Close() error {
-	w.writer = make([]string, 0)
+	w.writer = new(bytes.Buffer)
+	w.separatorIndices = make([]int, 0)
 	return nil
 }

--- a/json_serialization_writer.go
+++ b/json_serialization_writer.go
@@ -607,22 +607,17 @@ func (w *JsonSerializationWriter) WriteCollectionOfInt8Values(key string, collec
 
 // GetSerializedContent returns the resulting byte array from the serialization writer.
 func (w *JsonSerializationWriter) GetSerializedContent() ([]byte, error) {
-	written := w.writer.Bytes()
-	writtenLen := len(written)
-	trimmed := make([]byte, 0, writtenLen)
+	trimmed := w.writer.Bytes()
+	buffLen := len(trimmed)
 
-	sliceStart := 0
-	for _, idx := range w.separatorIndices {
-		trimmed = append(trimmed, written[sliceStart:idx]...)
-		sliceStart = idx
+	for i := len(w.separatorIndices) - 1; i >= 0; i-- {
+		idx := w.separatorIndices[i]
 
-		if idx == writtenLen-1 || idx < writtenLen-1 && (written[idx+1] == byte(']') || written[idx+1] == byte('}') || written[idx+1] == byte(',')) {
-			sliceStart++
+		if idx == buffLen-1 {
+			trimmed = trimmed[0:idx]
+		} else if trimmed[idx+1] == byte(']') || trimmed[idx+1] == byte('}') {
+			trimmed = append(trimmed[0:idx], trimmed[idx+1:]...)
 		}
-	}
-
-	if sliceStart <= writtenLen-1 {
-		trimmed = append(trimmed, written[sliceStart:]...)
 	}
 
 	return trimmed, nil

--- a/json_serialization_writer_test.go
+++ b/json_serialization_writer_test.go
@@ -194,6 +194,7 @@ func TestWriteInvalidAdditionalData(t *testing.T) {
 	err := serializer.WriteAdditionalData(adlData)
 	assert.Nil(t, err)
 	result, err := serializer.GetSerializedContent()
+	assert.NoError(t, err)
 
 	stringResult := string(result[:])
 	assert.Contains(t, stringResult, "\"pointer_node\":")

--- a/json_serialization_writer_test.go
+++ b/json_serialization_writer_test.go
@@ -3,9 +3,10 @@ package jsonserialization
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/microsoft/kiota-serialization-json-go/internal"
 	"testing"
 	"time"
+
+	"github.com/microsoft/kiota-serialization-json-go/internal"
 
 	assert "github.com/stretchr/testify/assert"
 
@@ -108,7 +109,7 @@ func TestWriteByteValue(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("\"key\":%d", value), string(result[:]))
 }
 
-//  ByteArray values are encoded to Base64 when stored
+// ByteArray values are encoded to Base64 when stored
 func TestWriteByteArrayValue(t *testing.T) {
 	serializer := NewJsonSerializationWriter()
 	value := []byte("SerialWriter")
@@ -214,6 +215,21 @@ func TestEscapesNewLinesInStrings(t *testing.T) {
 	result, err := serializer.GetSerializedContent()
 	assert.Nil(t, err)
 	assert.Equal(t, "\"key\":\"value\\nwith\\nnew\\nlines\"", string(result[:]))
+
+	fullPayload := "{" + string(result[:]) + "}"
+	var parsedResult TestStruct
+	parseErr := json.Unmarshal([]byte(fullPayload), &parsedResult)
+	assert.Nil(t, parseErr)
+	assert.Equal(t, value, parsedResult.Key)
+}
+
+func TestPreserveSeparatorsInStrings(t *testing.T) {
+	serializer := NewJsonSerializationWriter()
+	value := `{"foo":"bar","biz":"bang"},[1,2,3,],,`
+	serializer.WriteStringValue("key", &value)
+	result, err := serializer.GetSerializedContent()
+	assert.Nil(t, err)
+	assert.Equal(t, `"key":"{\"foo\":\"bar\",\"biz\":\"bang\"},[1,2,3,],,"`, string(result))
 
 	fullPayload := "{" + string(result[:]) + "}"
 	var parsedResult TestStruct


### PR DESCRIPTION
These changes improve `JsonSerializationWriter` performance by roughly 50% or more (depends on the benchmark). The improvement is a result of using a buffer rather than concatenating strings to build the output.

Comparison:
```
Current   	  284647	      3717 ns/op	    5368 B/op	      55 allocs/op
Refactor   	  477813	      2499 ns/op	    2040 B/op	      22 allocs/op
```

Benchmark:
```go
func BenchmarkBuffer(b *testing.B) {
	value := "value\nwith\nnew\nlines"
	v := int64(100)
	for i := 0; i < b.N; i++ {
		serializer := NewJsonSerializationWriter()
		for k := 0; k < 5; k++ {
			serializer.WriteInt64Value("value", &v)
			serializer.WriteCollectionOfStringValues("stuff", []string{"abc", "def", "ghi"})
			serializer.WriteStringValue("key", &value)
		}

		_, err := serializer.GetSerializedContent()
		if err != nil {
			b.Error(err)
		}
		serializer.Close()
	}
}
```