### PR TITLE
Use buffer pools for JsonSerializationWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 
+## [0.9.3] - 2023-04-24
+
+### Changed
+
+- Use buffer pool for `JsonSerializationWriter`.
+
 ## [0.9.2] - 2023-04-17
 
 ### Changed

--- a/json_serialization_writer_test.go
+++ b/json_serialization_writer_test.go
@@ -129,14 +129,14 @@ func TestDoubleEscapeFailure(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("\"key\":%q", value), string(result[:]))
 }
 
-func TestBufferClose(t *testing.T) {
+func TestReset(t *testing.T) {
 	serializer := NewJsonSerializationWriter()
 	value := "W/\"CQAAABYAAAAs+XSiyjZdS4Rhtwk0v1pGAAC5bsJ2\""
 	serializer.WriteStringValue("key", &value)
 	result, err := serializer.GetSerializedContent()
 	assert.Nil(t, err)
 	assert.True(t, len(result) > 0)
-	serializer.Close()
+	serializer.Reset()
 	assert.True(t, len(result) > 0)
 	empty, err := serializer.GetSerializedContent()
 	assert.Nil(t, err)
@@ -146,6 +146,18 @@ func TestBufferClose(t *testing.T) {
 	notEmpty, err := serializer.GetSerializedContent()
 	assert.Nil(t, err)
 	assert.True(t, len(notEmpty) > 0)
+}
+
+func TestClose(t *testing.T) {
+	serializer := NewJsonSerializationWriter()
+	serializer.Close()
+	assert.Panics(t, func() {
+		serializer.GetSerializedContent()
+	})
+	assert.Panics(t, serializer.writer.Reset)
+	assert.NotPanics(t, func() {
+		serializer.Close()
+	})
 }
 
 func TestJsonSerializationWriterHonoursInterface(t *testing.T) {
@@ -194,7 +206,6 @@ func TestWriteInvalidAdditionalData(t *testing.T) {
 	err := serializer.WriteAdditionalData(adlData)
 	assert.Nil(t, err)
 	result, err := serializer.GetSerializedContent()
-	assert.NoError(t, err)
 
 	stringResult := string(result[:])
 	assert.Contains(t, stringResult, "\"pointer_node\":")


### PR DESCRIPTION
This PR depends on https://github.com/microsoft/kiota-serialization-json-go/pull/79

Creating and garbage collecting buffers is expensive and can have a significant impact in scenarios with high concurrency. This change improves serialization performance by utilizing a buffer pool. 

I also made the `Close` semantics more idiomatic by making it a true finalizer. The existing behavior is what most Go packages would wrap in a `Reset` function. The current behavior is counterintuitive because I typically wouldn’t expect to reuse a struct after I had called `Close` on it.

The existing `Close` implementation also has the disadvantage of allocating a new buffer even when there is no intent to reuse the writer. If a user is always calling `Close` before disposing the writer, they’re unwittingly hurting performance by doubling buffer allocations and increasing the effort required to clean them up.

Same benchmark as https://github.com/microsoft/kiota-serialization-json-go/pull/79

```
BenchmarkNoPool-10    	  477813	      2499 ns/op	    2040 B/op	      22 allocs/op
BenchmarkPool-10     	  525110	      2277 ns/op	     648 B/op	      16 allocs/op
```