### PR TITLE
Fix/null serialization collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.2] - 2023-06-14
+
+- Safely serialize null values in collections of Objects, Enums or primitives.
+
+### Changed
+
 ## [1.0.1] - 2023-05-25
 
 - Fixes bug where slices backing data from `GetSerializedContent` could be overwritten before they were used but after `JsonSerializationWriter.Close()` was called.

--- a/internal/test_entity.go
+++ b/internal/test_entity.go
@@ -37,6 +37,10 @@ type TestEntityable interface {
 	SetCreatedDateTime(value *time.Time)
 }
 
+func TestEntityDiscriminator(absser.ParseNode) (absser.Parsable, error) {
+	return NewTestEntity(), nil
+}
+
 func NewTestEntity() *TestEntity {
 	return &TestEntity{
 		additionalData: make(map[string]interface{}),

--- a/json_parse_node.go
+++ b/json_parse_node.go
@@ -247,11 +247,15 @@ func (n *JsonParseNode) GetCollectionOfObjectValues(ctor absser.ParsableFactory)
 	}
 	result := make([]absser.Parsable, len(nodes))
 	for i, v := range nodes {
-		val, err := (*v).GetObjectValue(ctor)
-		if err != nil {
-			return nil, err
+		if v != nil {
+			val, err := (*v).GetObjectValue(ctor)
+			if err != nil {
+				return nil, err
+			}
+			result[i] = val
+		} else {
+			result[i] = nil
 		}
-		result[i] = val
 	}
 	return result, nil
 }
@@ -270,11 +274,15 @@ func (n *JsonParseNode) GetCollectionOfPrimitiveValues(targetType string) ([]int
 	}
 	result := make([]interface{}, len(nodes))
 	for i, v := range nodes {
-		val, err := v.getPrimitiveValue(targetType)
-		if err != nil {
-			return nil, err
+		if v != nil {
+			val, err := v.getPrimitiveValue(targetType)
+			if err != nil {
+				return nil, err
+			}
+			result[i] = val
+		} else {
+			result[i] = nil
 		}
-		result[i] = val
 	}
 	return result, nil
 }
@@ -327,11 +335,15 @@ func (n *JsonParseNode) GetCollectionOfEnumValues(parser absser.EnumFactory) ([]
 	}
 	result := make([]interface{}, len(nodes))
 	for i, v := range nodes {
-		val, err := v.GetEnumValue(parser)
-		if err != nil {
-			return nil, err
+		if v != nil {
+			val, err := v.GetEnumValue(parser)
+			if err != nil {
+				return nil, err
+			}
+			result[i] = val
+		} else {
+			result[i] = nil
 		}
-		result[i] = val
 	}
 	return result, nil
 }


### PR DESCRIPTION
Adds nill/null safety in serialization of a collection of variables.  Null values in a collection of strings, objects or primitives would result in crash during serialization.

Partially address issue in serialization https://github.com/microsoft/kiota-serialization-json-go/issues/91