### PR TITLE
Adds values of unamed array to additional data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.1.0] - 2023-07-11
+
+### Added
+
+- Adds `ArraysAdditionalData` in additional data to hold serialized array or arrays.
+
 ## [1.0.3] - 2023-06-28
 
 ### Changed

--- a/internal/json.go
+++ b/internal/json.go
@@ -1,0 +1,120 @@
+package internal
+
+import (
+	i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91 "github.com/microsoft/kiota-abstractions-go/serialization"
+	ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb92b7d971ed2d49a392e "github.com/microsoft/kiota-abstractions-go/store"
+)
+
+// Json
+type Json struct {
+	// Stores model information.
+	backingStore ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb92b7d971ed2d49a392e.BackingStore
+}
+
+// NewJson instantiates a new Json and sets the default values.
+func NewJson() *Json {
+	m := &Json{}
+	m.backingStore = ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb92b7d971ed2d49a392e.BackingStoreFactoryInstance()
+	m.SetAdditionalData(make(map[string]any))
+	return m
+}
+
+// CreateJsonFromDiscriminatorValue creates a new instance of the appropriate class based on discriminator value
+func CreateJsonFromDiscriminatorValue(parseNode i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode) (i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable, error) {
+	return NewJson(), nil
+}
+
+// GetAdditionalData gets the additionalData property value. Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+func (m *Json) GetAdditionalData() map[string]any {
+	val, err := m.backingStore.Get("additionalData")
+	if err != nil {
+		panic(err)
+	}
+	if val == nil {
+		var value = make(map[string]any)
+		m.SetAdditionalData(value)
+	}
+	return val.(map[string]any)
+}
+
+// GetBackingStore gets the backingStore property value. Stores model information.
+func (m *Json) GetBackingStore() ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb92b7d971ed2d49a392e.BackingStore {
+	return m.backingStore
+}
+
+// GetFieldDeserializers the deserialization information for the current model
+func (m *Json) GetFieldDeserializers() map[string]func(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode) error {
+	res := make(map[string]func(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode) error)
+	res["@odata.type"] = func(n i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode) error {
+		val, err := n.GetStringValue()
+		if err != nil {
+			return err
+		}
+		if val != nil {
+			m.SetOdataType(val)
+		}
+		return nil
+	}
+	return res
+}
+
+// GetOdataType gets the @odata.type property value. The OdataType property
+func (m *Json) GetOdataType() *string {
+	val, err := m.GetBackingStore().Get("odataType")
+	if err != nil {
+		panic(err)
+	}
+	if val != nil {
+		return val.(*string)
+	}
+	return nil
+}
+
+// Serialize serializes information the current object
+func (m *Json) Serialize(writer i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.SerializationWriter) error {
+	{
+		err := writer.WriteStringValue("@odata.type", m.GetOdataType())
+		if err != nil {
+			return err
+		}
+	}
+	{
+		err := writer.WriteAdditionalData(m.GetAdditionalData())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetAdditionalData sets the additionalData property value. Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+func (m *Json) SetAdditionalData(value map[string]any) {
+	err := m.GetBackingStore().Set("additionalData", value)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// SetBackingStore sets the backingStore property value. Stores model information.
+func (m *Json) SetBackingStore(value ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb92b7d971ed2d49a392e.BackingStore) {
+	m.backingStore = value
+}
+
+// SetOdataType sets the @odata.type property value. The OdataType property
+func (m *Json) SetOdataType(value *string) {
+	err := m.GetBackingStore().Set("odataType", value)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Jsonable
+type Jsonable interface {
+	i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.AdditionalDataHolder
+	ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb92b7d971ed2d49a392e.BackedModel
+	i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable
+	GetBackingStore() ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb92b7d971ed2d49a392e.BackingStore
+	GetOdataType() *string
+	SetBackingStore(value ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb92b7d971ed2d49a392e.BackingStore)
+	SetOdataType(value *string)
+}

--- a/internal/json.go
+++ b/internal/json.go
@@ -26,14 +26,7 @@ func CreateJsonFromDiscriminatorValue(parseNode i878a80d2330e89d26896388a3f487ee
 
 // GetAdditionalData gets the additionalData property value. Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
 func (m *Json) GetAdditionalData() map[string]any {
-	val, err := m.backingStore.Get("additionalData")
-	if err != nil {
-		panic(err)
-	}
-	if val == nil {
-		var value = make(map[string]any)
-		m.SetAdditionalData(value)
-	}
+	val, _ := m.backingStore.Get("additionalData")
 	return val.(map[string]any)
 }
 
@@ -44,46 +37,11 @@ func (m *Json) GetBackingStore() ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb9
 
 // GetFieldDeserializers the deserialization information for the current model
 func (m *Json) GetFieldDeserializers() map[string]func(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode) error {
-	res := make(map[string]func(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode) error)
-	res["@odata.type"] = func(n i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode) error {
-		val, err := n.GetStringValue()
-		if err != nil {
-			return err
-		}
-		if val != nil {
-			m.SetOdataType(val)
-		}
-		return nil
-	}
-	return res
-}
-
-// GetOdataType gets the @odata.type property value. The OdataType property
-func (m *Json) GetOdataType() *string {
-	val, err := m.GetBackingStore().Get("odataType")
-	if err != nil {
-		panic(err)
-	}
-	if val != nil {
-		return val.(*string)
-	}
-	return nil
+	return make(map[string]func(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode) error)
 }
 
 // Serialize serializes information the current object
-func (m *Json) Serialize(writer i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.SerializationWriter) error {
-	{
-		err := writer.WriteStringValue("@odata.type", m.GetOdataType())
-		if err != nil {
-			return err
-		}
-	}
-	{
-		err := writer.WriteAdditionalData(m.GetAdditionalData())
-		if err != nil {
-			return err
-		}
-	}
+func (m *Json) Serialize(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.SerializationWriter) error {
 	return nil
 }
 
@@ -98,23 +56,4 @@ func (m *Json) SetAdditionalData(value map[string]any) {
 // SetBackingStore sets the backingStore property value. Stores model information.
 func (m *Json) SetBackingStore(value ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb92b7d971ed2d49a392e.BackingStore) {
 	m.backingStore = value
-}
-
-// SetOdataType sets the @odata.type property value. The OdataType property
-func (m *Json) SetOdataType(value *string) {
-	err := m.GetBackingStore().Set("odataType", value)
-	if err != nil {
-		panic(err)
-	}
-}
-
-// Jsonable
-type Jsonable interface {
-	i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.AdditionalDataHolder
-	ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb92b7d971ed2d49a392e.BackedModel
-	i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable
-	GetBackingStore() ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb92b7d971ed2d49a392e.BackingStore
-	GetOdataType() *string
-	SetBackingStore(value ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb92b7d971ed2d49a392e.BackingStore)
-	SetOdataType(value *string)
 }

--- a/json_parse_node.go
+++ b/json_parse_node.go
@@ -231,7 +231,6 @@ func (n *JsonParseNode) GetObjectValue(ctor absser.ParsableFactory) (absser.Pars
 			}
 		}
 	}
-
 	if !ok {
 		// try cast to JsonParseNode array and read each value
 		nodes, okArray := n.value.([]*JsonParseNode)

--- a/json_parse_node.go
+++ b/json_parse_node.go
@@ -235,15 +235,13 @@ func (n *JsonParseNode) GetObjectValue(ctor absser.ParsableFactory) (absser.Pars
 	if !ok {
 		// try cast to JsonParseNode array and read each value
 		nodes, okArray := n.value.([]*JsonParseNode)
-		if okArray {
-			itemAsHolder, isHolder := result.(absser.AdditionalDataHolder)
+		itemAsHolder, isHolder := result.(absser.AdditionalDataHolder)
+		if okArray && isHolder {
 			var itemAdditionalData map[string]interface{}
-			if isHolder {
-				itemAdditionalData = itemAsHolder.GetAdditionalData()
-				if itemAdditionalData == nil {
-					itemAdditionalData = make(map[string]interface{})
-					itemAsHolder.SetAdditionalData(itemAdditionalData)
-				}
+			itemAdditionalData = itemAsHolder.GetAdditionalData()
+			if itemAdditionalData == nil {
+				itemAdditionalData = make(map[string]interface{})
+				itemAsHolder.SetAdditionalData(itemAdditionalData)
 			}
 
 			arrayValues := make([]interface{}, len(nodes))

--- a/json_parse_node_test.go
+++ b/json_parse_node_test.go
@@ -215,7 +215,15 @@ func TestSerializationOfUnamedMaps(t *testing.T) {
 	someProp, err := parseNode.GetChildNode("values")
 	value, err := someProp.GetObjectValue(internal.CreateJsonFromDiscriminatorValue)
 	jsonValue := value.(*internal.Json)
-	assert.Equal(t, "0", jsonValue.GetAdditionalData())
+	arrayValues := jsonValue.GetAdditionalData()[ArraysAdditionalData].([]interface{})
+	assert.Equal(t, "Name", *arrayValues[0].([]interface{})[0].(*string))
+	assert.Equal(t, "Amount", *arrayValues[0].([]interface{})[1].(*string))
+
+	assert.Equal(t, "Tony", *arrayValues[1].([]interface{})[0].(*string))
+	assert.Equal(t, float64(100), *arrayValues[1].([]interface{})[1].(*float64))
+
+	assert.Equal(t, "John", *arrayValues[2].([]interface{})[0].(*string))
+	assert.Equal(t, float64(200), *arrayValues[2].([]interface{})[1].(*float64))
 }
 
 const FunctionalTestSource = "{" +

--- a/json_parse_node_test.go
+++ b/json_parse_node_test.go
@@ -197,6 +197,27 @@ func TestThrowErrorOfPrimitiveType(t *testing.T) {
 	assert.Equal(t, "targetType wrong.UUID is not supported", err.Error())
 }
 
+func TestSerializationOfUnamedMaps(t *testing.T) {
+	source := `{
+				"values": [
+					["Name", "Amount"],
+					["Tony"	, 100],
+					["John"	, 200],
+					["Mary"	, 300]
+				]
+		  }`
+	sourceArray := []byte(source)
+	parseNode, err := NewJsonParseNode(sourceArray)
+	if err != nil {
+		t.Errorf("Error creating parse node: %s", err.Error())
+	}
+
+	someProp, err := parseNode.GetChildNode("values")
+	value, err := someProp.GetObjectValue(internal.CreateJsonFromDiscriminatorValue)
+	jsonValue := value.(*internal.Json)
+	assert.Equal(t, "0", jsonValue.GetAdditionalData())
+}
+
 const FunctionalTestSource = "{" +
 	"\"@odata.context\": \"https://graph.microsoft.com/v1.0/$metadata#users('vincent%40biret365.onmicrosoft.com')/messages\"," +
 	"\"@odata.nextLink\": \"https://graph.microsoft.com/v1.0/users/vincent@biret365.onmicrosoft.com/messages?$skip=10\"," +


### PR DESCRIPTION
Currenty serialization of an array of arrays into additional data results in a complete loss of the data in the array. Additional data can only hold a key value pair i.e if an array is a direct decendant of an array the values are lost.

This fix introduces a constant `ArraysAdditionalData` in the additional data and saves the unnamed arrays to the value and prevent data loss


A possible fix for https://github.com/microsoftgraph/msgraph-sdk-go/issues/473