### PR TITLE
Allows serialization of time without zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.4] - 2023-07-12
+
+### Changed
+
+- Fixes parsing time parsing without timezone information.
+
 ## [1.0.3] - 2023-06-28
 
 ### Changed

--- a/json_parse_node.go
+++ b/json_parse_node.go
@@ -441,6 +441,11 @@ func (n *JsonParseNode) GetTimeValue() (*time.Time, error) {
 	if v == nil {
 		return nil, nil
 	}
+
+	// if string does not have timezone information, add local timezone
+	if len(*v) == 19 {
+		*v = *v + time.Now().Format("-07:00")
+	}
 	parsed, err := time.Parse(time.RFC3339, *v)
 	return &parsed, err
 }

--- a/json_parse_node_test.go
+++ b/json_parse_node_test.go
@@ -182,7 +182,7 @@ func TestFunctional(t *testing.T) {
 func TestParsingTime(t *testing.T) {
 	source := `{
 			"noZone": "2023-07-12T08:54:24",
-			"withZone": "2023-07-12T08:54:24"
+			"withZone": "2023-07-12T09:54:24+03:00"
 	  }`
 
 	sourceArray := []byte(source)
@@ -196,6 +196,12 @@ func TestParsingTime(t *testing.T) {
 	time1, err := someProp.GetTimeValue()
 	assert.Nil(t, err)
 	assert.Contains(t, time1.String(), "2023-07-12 08:54:24 +")
+
+	someProp2, err := parseNode.GetChildNode("withZone")
+	assert.Nil(t, err)
+	time2, err := someProp2.GetTimeValue()
+	assert.Nil(t, err)
+	assert.Contains(t, time2.String(), "2023-07-12 09:54:24 +")
 }
 
 func TestThrowErrorOfPrimitiveType(t *testing.T) {

--- a/json_parse_node_test.go
+++ b/json_parse_node_test.go
@@ -179,6 +179,25 @@ func TestFunctional(t *testing.T) {
 	}
 }
 
+func TestParsingTime(t *testing.T) {
+	source := `{
+			"noZone": "2023-07-12T08:54:24",
+			"withZone": "2023-07-12T08:54:24"
+	  }`
+
+	sourceArray := []byte(source)
+	parseNode, err := NewJsonParseNode(sourceArray)
+	if err != nil {
+		t.Errorf("Error creating parse node: %s", err.Error())
+	}
+
+	someProp, err := parseNode.GetChildNode("noZone")
+	assert.Nil(t, err)
+	time1, err := someProp.GetTimeValue()
+	assert.Nil(t, err)
+	assert.Contains(t, time1.String(), "2023-07-12T08:54:24 +")
+}
+
 func TestThrowErrorOfPrimitiveType(t *testing.T) {
 	source := `{
 				"id": "2",

--- a/json_parse_node_test.go
+++ b/json_parse_node_test.go
@@ -195,7 +195,7 @@ func TestParsingTime(t *testing.T) {
 	assert.Nil(t, err)
 	time1, err := someProp.GetTimeValue()
 	assert.Nil(t, err)
-	assert.Contains(t, time1.String(), "2023-07-12T08:54:24 +")
+	assert.Contains(t, time1.String(), "2023-07-12 08:54:24 +")
 }
 
 func TestThrowErrorOfPrimitiveType(t *testing.T) {


### PR DESCRIPTION
`GetTimeValue` fails when the time zone information is excluded during parsing a time value. This fix allows allows time values without time zone information and assumes the users local timezone when time zone is not passed


Resolves https://github.com/microsoftgraph/msgraph-sdk-go-core/issues/212