### PR TITLE
Use golang standard library to serialize strings to JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.5] - 2024-01-10
+
 ### Changed
+
+- Fixes some special character escaping when serializing strings to JSON. Previous incorrect escaping could lead to deserialization errors if old serialized data is read again.
 
 ## [1.0.4] - 2023-07-12
 

--- a/json_serialization_writer.go
+++ b/json_serialization_writer.go
@@ -53,6 +53,11 @@ func (w *JsonSerializationWriter) writeRawValue(value ...string) {
 }
 func (w *JsonSerializationWriter) writeStringValue(value string) {
 	builder := &strings.Builder{}
+	// Allocate at least enough space for the string and quotes. However, it's
+	// possible that slightly overallocating may be a better strategy because then
+	// it would at least be able to handle a few character escape sequences
+	// without another allocation.
+	builder.Grow(len(value) + 2)
 
 	// Turning off HTML escaping may not be strictly necessary but it matches with
 	// the current behavior. Testing with Exchange mail shows that it will

--- a/json_serialization_writer_test.go
+++ b/json_serialization_writer_test.go
@@ -296,12 +296,16 @@ func TestShortEscapeSequencesInString(t *testing.T) {
 			expected: []byte(`"\\"`),
 		},
 		{
-			input:    0x08, // backspace character
-			expected: []byte(`"\b"`),
+			input: 0x08, // backspace character
+			// Until go1.22 is released this will be the more generic \u0008 escape
+			// code.
+			expected: []byte(`"\u0008"`),
 		},
 		{
-			input:    0x0c, // form feed character
-			expected: []byte(`"\f"`),
+			input: 0x0c, // form feed character
+			// Until go1.22 is released this will be the more generic \u000c escape
+			// code.
+			expected: []byte(`"\u000c"`),
 		},
 		{
 			input:    0x0a, // line feed character
@@ -318,7 +322,7 @@ func TestShortEscapeSequencesInString(t *testing.T) {
 	}
 
 	for _, test := range table {
-		t.Run(fmt.Sprintf("%02X", test.input), func(t *testing.T) {
+		t.Run(fmt.Sprintf("0x%02X", test.input), func(t *testing.T) {
 			stringInput := string(test.input)
 
 			serializer := NewJsonSerializationWriter()
@@ -380,15 +384,15 @@ func TestLongEscapeSequencesInString(t *testing.T) {
 		},
 		{
 			input:    0x0b,
-			expected: []byte(`"\u000B"`),
+			expected: []byte(`"\u000b"`),
 		},
 		{
 			input:    0x0e,
-			expected: []byte(`"\u000E"`),
+			expected: []byte(`"\u000e"`),
 		},
 		{
 			input:    0x0f,
-			expected: []byte(`"\u000F"`),
+			expected: []byte(`"\u000f"`),
 		},
 		{
 			input:    0x10,
@@ -432,32 +436,32 @@ func TestLongEscapeSequencesInString(t *testing.T) {
 		},
 		{
 			input:    0x1a,
-			expected: []byte(`"\u001A"`),
+			expected: []byte(`"\u001a"`),
 		},
 		{
 			input:    0x1b,
-			expected: []byte(`"\u001B"`),
+			expected: []byte(`"\u001b"`),
 		},
 		{
 			input:    0x1c,
-			expected: []byte(`"\u001C"`),
+			expected: []byte(`"\u001c"`),
 		},
 		{
 			input:    0x1d,
-			expected: []byte(`"\u001D"`),
+			expected: []byte(`"\u001d"`),
 		},
 		{
 			input:    0x1e,
-			expected: []byte(`"\u001E"`),
+			expected: []byte(`"\u001e"`),
 		},
 		{
 			input:    0x1f,
-			expected: []byte(`"\u001F"`),
+			expected: []byte(`"\u001f"`),
 		},
 	}
 
 	for _, test := range table {
-		t.Run(fmt.Sprintf("%02X", test.input), func(t *testing.T) {
+		t.Run(fmt.Sprintf("0x%02X", test.input), func(t *testing.T) {
 			stringInput := string(test.input)
 
 			serializer := NewJsonSerializationWriter()

--- a/json_serialization_writer_test.go
+++ b/json_serialization_writer_test.go
@@ -278,6 +278,202 @@ func TestEscapeTabAndCarriageReturnInStrings(t *testing.T) {
 	assert.Equal(t, expected, converted)
 }
 
+// TestShortEscapeSequencesInString tests that strings containing characters
+// with 2-character escape sequences according to RFC 8259 section 7 are
+// properly encoded as JSON.
+func TestShortEscapeSequencesInString(t *testing.T) {
+	// Expected results for each test are quoted since it's a JSON string.
+	table := []struct {
+		input    byte
+		expected []byte
+	}{
+		{
+			input:    0x22, // " character
+			expected: []byte(`"\""`),
+		},
+		{
+			input:    0x5c, // \ character
+			expected: []byte(`"\\"`),
+		},
+		{
+			input:    0x08, // backspace character
+			expected: []byte(`"\b"`),
+		},
+		{
+			input:    0x0c, // form feed character
+			expected: []byte(`"\f"`),
+		},
+		{
+			input:    0x0a, // line feed character
+			expected: []byte(`"\n"`),
+		},
+		{
+			input:    0x0d, // carriage return character
+			expected: []byte(`"\r"`),
+		},
+		{
+			input:    0x09, // tab character
+			expected: []byte(`"\t"`),
+		},
+	}
+
+	for _, test := range table {
+		t.Run(fmt.Sprintf("%02X", test.input), func(t *testing.T) {
+			stringInput := string(test.input)
+
+			serializer := NewJsonSerializationWriter()
+			err := serializer.WriteStringValue("", &stringInput)
+			assert.NoError(t, err)
+
+			result, err := serializer.GetSerializedContent()
+			assert.NoError(t, err)
+
+			assert.Equal(t, test.expected, result)
+
+			assert.True(t, json.Valid(result), "valid JSON")
+		})
+	}
+}
+
+// TestLongEscapeSequencesInString tests that strings containing characters
+// without 2-character escape sequences according to RFC 8259 section 7 are
+// properly encoded as JSON.
+func TestLongEscapeSequencesInString(t *testing.T) {
+	// Manually adding these expected results since the code to generate them with
+	// a loop would be pretty similar to the code to generate the escape sequences
+	// which could make it susceptible to similar logic errors.
+	table := []struct {
+		input    byte
+		expected []byte
+	}{
+		{
+			input:    0x00,
+			expected: []byte(`"\u0000"`),
+		},
+		{
+			input:    0x01,
+			expected: []byte(`"\u0001"`),
+		},
+		{
+			input:    0x02,
+			expected: []byte(`"\u0002"`),
+		},
+		{
+			input:    0x03,
+			expected: []byte(`"\u0003"`),
+		},
+		{
+			input:    0x04,
+			expected: []byte(`"\u0004"`),
+		},
+		{
+			input:    0x05,
+			expected: []byte(`"\u0005"`),
+		},
+		{
+			input:    0x06,
+			expected: []byte(`"\u0006"`),
+		},
+		{
+			input:    0x07,
+			expected: []byte(`"\u0007"`),
+		},
+		{
+			input:    0x0b,
+			expected: []byte(`"\u000B"`),
+		},
+		{
+			input:    0x0e,
+			expected: []byte(`"\u000E"`),
+		},
+		{
+			input:    0x0f,
+			expected: []byte(`"\u000F"`),
+		},
+		{
+			input:    0x10,
+			expected: []byte(`"\u0010"`),
+		},
+		{
+			input:    0x11,
+			expected: []byte(`"\u0011"`),
+		},
+		{
+			input:    0x12,
+			expected: []byte(`"\u0012"`),
+		},
+		{
+			input:    0x13,
+			expected: []byte(`"\u0013"`),
+		},
+		{
+			input:    0x14,
+			expected: []byte(`"\u0014"`),
+		},
+		{
+			input:    0x15,
+			expected: []byte(`"\u0015"`),
+		},
+		{
+			input:    0x16,
+			expected: []byte(`"\u0016"`),
+		},
+		{
+			input:    0x17,
+			expected: []byte(`"\u0017"`),
+		},
+		{
+			input:    0x18,
+			expected: []byte(`"\u0018"`),
+		},
+		{
+			input:    0x19,
+			expected: []byte(`"\u0019"`),
+		},
+		{
+			input:    0x1a,
+			expected: []byte(`"\u001A"`),
+		},
+		{
+			input:    0x1b,
+			expected: []byte(`"\u001B"`),
+		},
+		{
+			input:    0x1c,
+			expected: []byte(`"\u001C"`),
+		},
+		{
+			input:    0x1d,
+			expected: []byte(`"\u001D"`),
+		},
+		{
+			input:    0x1e,
+			expected: []byte(`"\u001E"`),
+		},
+		{
+			input:    0x1f,
+			expected: []byte(`"\u001F"`),
+		},
+	}
+
+	for _, test := range table {
+		t.Run(fmt.Sprintf("%02X", test.input), func(t *testing.T) {
+			stringInput := string(test.input)
+
+			serializer := NewJsonSerializationWriter()
+			err := serializer.WriteStringValue("", &stringInput)
+			assert.NoError(t, err)
+
+			result, err := serializer.GetSerializedContent()
+			assert.NoError(t, err)
+
+			assert.Equal(t, test.expected, result)
+
+			assert.True(t, json.Valid(result), "valid JSON")
+		})
+	}
+}
+
 func TestWriteValuesConcurrently(t *testing.T) {
 	instances := 100
 	output := make([][]byte, instances)


### PR DESCRIPTION
Fix #117 by using the golang standard library to serialize strings instead of using ad-hoc string replacements. This uses the encoder type so that HTML escaping can be disabled, producing the closest output to the original code. If it's alright to use HTML escaping then just `json.Marshal` could be used and the `strings.Builder` and string trimming wouldn't be required

One unexpected thing about this solution is that until at least go1.22 is used for the project backspace and form feed will be escaped as `\u0008` and `\u000c` instead of `\b` and `\f`. As this has been in the go standard library for several years it seems like it's probably not going to cause any issues. However, it's unclear how much usage those characters get in general, so it could just be that issues haven't cropped up

I did test creating emails with backspaces in their body and the graph server accepted it. I'm unsure if all graph services would take the input though