### PR TITLE
Fixes serialization of null in a collection of objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.6] - 2024-02-12
+
+### Changed
+
+- Fixes serilaization of `null` values in collections of Objects.
+
 ## [1.0.5] - 2024-01-10
 
 ### Changed

--- a/json_serialization_writer.go
+++ b/json_serialization_writer.go
@@ -331,9 +331,16 @@ func (w *JsonSerializationWriter) WriteCollectionOfObjectValues(key string, coll
 		}
 		w.writeArrayStart()
 		for _, item := range collection {
-			err := w.WriteObjectValue("", item)
-			if err != nil {
-				return err
+			if item != nil {
+				err := w.WriteObjectValue("", item)
+				if err != nil {
+					return err
+				}
+			} else {
+				err := w.WriteNullValue("")
+				if err != nil {
+					return err
+				}
 			}
 			w.writePropertySeparator()
 		}

--- a/json_serialization_writer_test.go
+++ b/json_serialization_writer_test.go
@@ -215,6 +215,27 @@ func TestWriteInvalidAdditionalData(t *testing.T) {
 	assert.True(t, IsJSON("{"+stringResult+"}"))
 }
 
+func TestWriteACollectionWithNill(t *testing.T) {
+	serializer := NewJsonSerializationWriter()
+	value := "value"
+	serializer.WriteStringValue("key", &value)
+
+	prop1Value1 := internal.NewTestEntity()
+	idIntValue1 := "11"
+	prop1Value1.SetId(&idIntValue1)
+
+	collection := []absser.Parsable{nil, prop1Value1}
+	err := serializer.WriteCollectionOfObjectValues("", collection)
+
+	assert.Nil(t, err)
+	result, err := serializer.GetSerializedContent()
+
+	stringResult := string(result[:])
+	assert.Contains(t, stringResult, "null,")
+	assert.Contains(t, stringResult, "\"key\":\"value\",[null,{\"id\":\"11\"}]")
+	assert.True(t, IsJSON("{"+stringResult+"}"))
+}
+
 func IsJSON(str string) bool {
 	var js json.RawMessage
 	err := json.Unmarshal([]byte(str), &js)

--- a/json_serialization_writer_test.go
+++ b/json_serialization_writer_test.go
@@ -233,7 +233,6 @@ func TestWriteACollectionWithNill(t *testing.T) {
 	stringResult := string(result[:])
 	assert.Contains(t, stringResult, "null,")
 	assert.Contains(t, stringResult, "\"key\":\"value\",[null,{\"id\":\"11\"}]")
-	assert.True(t, IsJSON("{"+stringResult+"}"))
 }
 
 func IsJSON(str string) bool {


### PR DESCRIPTION
when serialization a collection of Parseable, a null value leave an empty space between comma separated values, This fix replaces the empty space with a "null" in the payload.

Fixes https://github.com/microsoftgraph/msgraph-sdk-go/issues/518
