### PR TITLE
fix: parse numbers encoded as JSON strings in numeric getters

### DIFF
--- a/json_parse_node_test.go
+++ b/json_parse_node_test.go
@@ -435,8 +435,8 @@ func TestJsonGetInt8Value(t *testing.T) {
 		{
 			Title:    "String",
 			Input:    []byte(`"1"`),
-			Expected: (*int8)(nil),
-			Error:    errors.New("value '1' is not compatible with type int8"),
+			Expected: int8(1),
+			Error:    nil,
 		},
 		{
 			Title:    "Float",
@@ -445,8 +445,32 @@ func TestJsonGetInt8Value(t *testing.T) {
 			Error:    errors.New("value '1.1' is not compatible with type int8"),
 		},
 		{
+			Title:    "Invalid String",
+			Input:    []byte(`"abc"`),
+			Expected: (*int8)(nil),
+			Error:    errors.New("value 'abc' is not compatible with type int8"),
+		},
+		{
+			Title:    "Decimal String",
+			Input:    []byte(`"1.5"`),
+			Expected: (*int8)(nil),
+			Error:    errors.New("value '1.5' is not compatible with type int8"),
+		},
+		{
+			Title:    "Empty String",
+			Input:    []byte(`""`),
+			Expected: (*int8)(nil),
+			Error:    errors.New("value '' is not compatible with type int8"),
+		},
+		{
 			Title:    "Too Big",
 			Input:    []byte(`129`),
+			Expected: (*int8)(nil),
+			Error:    errors.New("value '129' is not compatible with type int8"),
+		},
+		{
+			Title:    "Too Big String",
+			Input:    []byte(`"129"`),
 			Expected: (*int8)(nil),
 			Error:    errors.New("value '129' is not compatible with type int8"),
 		},
@@ -499,14 +523,26 @@ func TestJsonGetByteValue(t *testing.T) {
 		{
 			Title:    "String",
 			Input:    []byte(`"1"`),
+			Expected: uint8(1),
+			Error:    nil,
+		},
+		{
+			Title:    "Invalid String",
+			Input:    []byte(`"abc"`),
 			Expected: (*uint8)(nil),
-			Error:    errors.New("value '1' is not compatible with type uint8"),
+			Error:    errors.New("value 'abc' is not compatible with type uint8"),
 		},
 		{
 			Title:    "Too Big",
 			Input:    []byte(`3.40283e+38`),
 			Expected: (*uint8)(nil),
 			Error:    errors.New("value '3.40283e+38' is not compatible with type uint8"),
+		},
+		{
+			Title:    "Too Big String",
+			Input:    []byte(`"256"`),
+			Expected: (*uint8)(nil),
+			Error:    errors.New("value '256' is not compatible with type uint8"),
 		},
 	}
 
@@ -551,8 +587,20 @@ func TestJsonGetFloat32Value(t *testing.T) {
 		{
 			Title:    "String",
 			Input:    []byte(`"1"`),
+			Expected: float32(1),
+			Error:    nil,
+		},
+		{
+			Title:    "Decimal String",
+			Input:    []byte(`"1.5"`),
+			Expected: float32(1.5),
+			Error:    nil,
+		},
+		{
+			Title:    "Invalid String",
+			Input:    []byte(`"abc"`),
 			Expected: (*float32)(nil),
-			Error:    errors.New("value '1' is not compatible with type float32"),
+			Error:    errors.New("value 'abc' is not compatible with type float32"),
 		},
 		{
 			Title:    "Too Big",
@@ -603,8 +651,20 @@ func TestJsonGetFloat64Value(t *testing.T) {
 		{
 			Title:    "String",
 			Input:    []byte(`"1"`),
+			Expected: float64(1),
+			Error:    nil,
+		},
+		{
+			Title:    "Decimal String",
+			Input:    []byte(`"1.5"`),
+			Expected: float64(1.5),
+			Error:    nil,
+		},
+		{
+			Title:    "Invalid String",
+			Input:    []byte(`"abc"`),
 			Expected: (*float64)(nil),
-			Error:    errors.New("value '1' is not compatible with type float64"),
+			Error:    errors.New("value 'abc' is not compatible with type float64"),
 		},
 		//NOTE: no point in checking too big, the STD JSON encoder will error out first :)
 	}
@@ -656,8 +716,32 @@ func TestJsonGetInt32Value(t *testing.T) {
 		{
 			Title:    "String",
 			Input:    []byte(`"1"`),
+			Expected: int32(1),
+			Error:    nil,
+		},
+		{
+			Title:    "Invalid String",
+			Input:    []byte(`"abc"`),
 			Expected: (*int32)(nil),
-			Error:    errors.New("value '1' is not compatible with type int32"),
+			Error:    errors.New("value 'abc' is not compatible with type int32"),
+		},
+		{
+			Title:    "Decimal String",
+			Input:    []byte(`"1.5"`),
+			Expected: (*int32)(nil),
+			Error:    errors.New("value '1.5' is not compatible with type int32"),
+		},
+		{
+			Title:    "Empty String",
+			Input:    []byte(`""`),
+			Expected: (*int32)(nil),
+			Error:    errors.New("value '' is not compatible with type int32"),
+		},
+		{
+			Title:    "Overflow String",
+			Input:    []byte(`"3000000000"`),
+			Expected: (*int32)(nil),
+			Error:    errors.New("value '3000000000' is not compatible with type int32"),
 		},
 		{
 			Title:    "Too Big",
@@ -712,6 +796,30 @@ func TestJsonGetInt64Value(t *testing.T) {
 			Error:    errors.New("value '1.1' is not compatible with type int64"),
 		},
 		{
+			Title:    "String",
+			Input:    []byte(`"1"`),
+			Expected: int64(1),
+			Error:    nil,
+		},
+		{
+			Title:    "Invalid String",
+			Input:    []byte(`"abc"`),
+			Expected: (*int64)(nil),
+			Error:    errors.New("value 'abc' is not compatible with type int64"),
+		},
+		{
+			Title:    "Decimal String",
+			Input:    []byte(`"1.5"`),
+			Expected: (*int64)(nil),
+			Error:    errors.New("value '1.5' is not compatible with type int64"),
+		},
+		{
+			Title:    "Empty String",
+			Input:    []byte(`""`),
+			Expected: (*int64)(nil),
+			Error:    errors.New("value '' is not compatible with type int64"),
+		},
+		{
 			Title:    "Too Big",
 			Input:    []byte(`3.40283e+38`),
 			Expected: (*int64)(nil),
@@ -736,6 +844,23 @@ func TestJsonGetInt64Value(t *testing.T) {
 			assert.Equal(t, test.Expected, val)
 		})
 	}
+}
+
+// TestJsonGetCollectionOfStringEncodedNumbers ensures the collection path (rawToPrimitiveValue)
+// also accepts numbers encoded as JSON strings, e.g. ["1","2","3"] into []int32.
+func TestJsonGetCollectionOfStringEncodedNumbers(t *testing.T) {
+	parseNode, err := NewJsonParseNode([]byte(`{"phones":["1","2","3"]}`))
+	assert.Nil(t, err)
+
+	prop, err := parseNode.GetChildNode("phones")
+	assert.Nil(t, err)
+
+	values, err := prop.GetCollectionOfPrimitiveValues("int32")
+	assert.Nil(t, err)
+	assert.Len(t, values, 3)
+	assert.Equal(t, int32(1), *(values[0].(*int32)))
+	assert.Equal(t, int32(2), *(values[1].(*int32)))
+	assert.Equal(t, int32(3), *(values[2].(*int32)))
 }
 
 const TestUntypedJson = "{\r\n" +

--- a/util.go
+++ b/util.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strconv"
+	"strings"
 )
 
 type numericRange struct {
@@ -89,6 +91,22 @@ func as[T any](in interface{}, out T) error {
 	}
 
 	outType := nestedOutVal.Type()
+
+	// Numbers encoded as JSON strings (e.g. "1") arrive here as a plain string after the
+	// pointer dereference above. Parse the string into a numeric value and run it through the
+	// same range/decimal compatibility checks used for native numbers, so callers get a value
+	// for valid strings ("1" -> int32(1), "1.5" -> float64(1.5)) and a clear error otherwise.
+	if s, ok := in.(string); ok && isNumericType(outType) {
+		parsed, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+		if err != nil {
+			return fmt.Errorf("value '%v' is not compatible with type %T", in, nestedOutVal.Interface())
+		}
+		if !isCompatibleInt(parsed, outType) {
+			return fmt.Errorf("value '%v' is not compatible with type %T", in, nestedOutVal.Interface())
+		}
+		outVal.Elem().Set(reflect.ValueOf(parsed).Convert(outType))
+		return nil
+	}
 
 	if !isCompatible(in, outType) {
 		return fmt.Errorf("value '%v' is not compatible with type %T", in, nestedOutVal.Interface())


### PR DESCRIPTION
## Summary

Fixes #174.

Microsoft Graph sometimes serializes numeric (`Edm.Int32`) fields as JSON **strings** rather than numbers. A concrete example is `driveItem.photo.orientation`, which the metamodel types as `Edm.Int32` but Graph emits as `"orientation": "1"`. When deserializing such a response, the numeric getters fail with:

```
value '1' is not compatible with type int32
```

This breaks otherwise valid responses — e.g. listing drive items (`Drives().ByDriveId(...).Items().Get(...)`) — even though the payload itself is fine. See also the related downstream report [microsoftgraph/msgraph-sdk-go#685](https://github.com/microsoftgraph/msgraph-sdk-go/issues/685).

## Root cause

`"1"` is stored as a `*string` in the parse node. All numeric getters (`GetInt8Value`, `GetByteValue`, `GetFloat32Value`, `GetFloat64Value`, `GetInt32Value`, `GetInt64Value`) and the collection path (`rawToPrimitiveValue`) route through the central `as[T any]` helper in `util.go`. For a string input and a numeric target, `isCompatible` falls through to `reflect.TypeOf(value).ConvertibleTo(tp)`, which is `false` for `string → numeric`, producing the error.

This strict behaviour is defensible in theory, but a consumer does not control what Graph returns and Graph is unlikely to change this long-standing quirk. The only workaround available downstream is to mutilate the request with a restricted `$select` so the offending field is never returned — which does not scale once the field is actually needed. A JSON deserializer whose job is to digest an API's responses should tolerate that API's documented quirks (Go's own `encoding/json` offers `,string` for exactly this case).

## Fix

A single, narrow change in `as()`: when the input is a `string` **and** the target is a numeric type, parse the string and run the parsed value through the **existing** range/decimal compatibility checks (`isCompatibleInt` / `numericTypeRanges`) before converting.

- Valid numbers parse: `"1" -> int32(1)`, `"1.5" -> float64(1.5)`.
- Clear errors are preserved: unparseable (`"abc"`), empty (`""`), out-of-range (`"3000000000"` into int32), and decimal-into-integer (`"1.5"` into int32) all still return the same `value '%v' is not compatible with type %T` error.
- Non-numeric targets (bool, string, time) take the unchanged path — no behaviour change.
- The fix is centralized, so all numeric getters and the primitive-collection path benefit at once.

## Tests

- Flipped the existing `"String"` cases (input `"1"`) from expecting an error to expecting success for int8, byte, float32, float64, int32; added the previously-missing success case for int64.
- Added negative cases: invalid string, empty string, decimal-into-integer, and overflow strings — asserting the clear error is preserved.
- Added decimal-string success cases for the float getters.
- Added `TestJsonGetCollectionOfStringEncodedNumbers` covering the collection path (`["1","2","3"] -> []int32`).

Validated end-to-end against the exact payload attached to the issue (`photo.orientation == "1"`): the getter that previously failed now returns `int32(1)`, while native-int fields in the same object are unaffected.

`go build`, `go vet`, `go test ./...` (incl. `-race`) all pass; `gofmt` clean.
